### PR TITLE
Dockerfile tini implementation and Using ARGs in Dockerfile FROM for dynamic image

### DIFF
--- a/Adoptopenjdk.Dockerfile
+++ b/Adoptopenjdk.Dockerfile
@@ -1,0 +1,32 @@
+ARG BUILDER_IMG_REPO=adoptopenjdk
+ARG BUILDER_IMG_TAG=11-jre
+ARG RELEASE_IMG_REPO=adoptopenjdk
+ARG RELEASE_IMG_TAG=11-jre
+FROM $BUILDER_IMG_REPO:$BUILDER_IMG_TAG AS Builder
+
+ARG CMAK_VERSION="3.0.0.5"
+
+RUN apt update -y && \
+    apt install -y zip && \
+    curl -L https://github.com/yahoo/CMAK/releases/download/${CMAK_VERSION}/cmak-${CMAK_VERSION}.zip -o /tmp/cmak.zip \
+    && unzip /tmp/cmak.zip -d / \
+    && ln -s /cmak-$CMAK_VERSION /cmak \
+    && rm -rf /tmp/cmak.zip
+
+FROM $RELEASE_IMG_REPO:$RELEASE_IMG_TAG
+LABEL maintainer="Hleb Albau <hleb.albau@gmail.com>" 
+
+COPY --from=Builder /cmak /cmak
+
+VOLUME /cmak/conf
+
+ENV JAVA_OPTS="-XX:+UseContainerSupport -XX:MaxRAMPercentage=80"
+
+WORKDIR /cmak
+
+# Add Tini
+ENV TINI_VERSION v0.19.0
+ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
+RUN chmod +x /tini
+ENTRYPOINT ["/tini", "--","/cmak/bin/cmak"]
+CMD ["-Dpidfile.path=/dev/null", "-Dapplication.home=/cmak", ""]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,8 @@
-FROM openjdk:11-jre as build
+ARG BUILDER_IMG_REPO=openjdk
+ARG BUILDER_IMG_TAG=11-jre
+ARG RELEASE_IMG_REPO=openjdk
+ARG RELEASE_IMG_TAG=11-jre-slim
+FROM $BUILDER_IMG_REPO:$BUILDER_IMG_TAG AS Builder
 
 ARG CMAK_VERSION="3.0.0.5"
 
@@ -7,16 +11,20 @@ RUN curl -L https://github.com/yahoo/CMAK/releases/download/${CMAK_VERSION}/cmak
     && ln -s /cmak-$CMAK_VERSION /cmak \
     && rm -rf /tmp/cmak.zip
 
-FROM openjdk:11-jre-slim
-MAINTAINER Hleb Albau <hleb.albau@gmail.com>
+FROM $RELEASE_IMG_REPO:$RELEASE_IMG_TAG 
+LABEL maintainer="Hleb Albau <hleb.albau@gmail.com>" 
 
-COPY --from=build /cmak /cmak
+COPY --from=Builder /cmak /cmak
 
 VOLUME /cmak/conf
 
-ENV JAVA_OPTS=-XX:MaxRAMPercentage=80
+ENV JAVA_OPTS="-XX:+UseContainerSupport -XX:MaxRAMPercentage=80"
 
 WORKDIR /cmak
 
-ENTRYPOINT ["/cmak/bin/cmak", "-Dpidfile.path=/dev/null", "-Dapplication.home=/cmak", ""]
-
+# Add Tini
+ENV TINI_VERSION v0.19.0
+ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
+RUN chmod +x /tini
+ENTRYPOINT ["/tini", "--","/cmak/bin/cmak"]
+CMD ["-Dpidfile.path=/dev/null", "-Dapplication.home=/cmak", ""]


### PR DESCRIPTION
Dockerfile Updated
- MAINTAINER instruction changed to LABEL
- Tini added
- Using ARGs in Dockerfile FROM for dynamic image

Adoptopenjdk.Dockerfile added 